### PR TITLE
Use HTTPS installation in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 # Install passwork-cli
-RUN pip install --no-cache-dir git+ssh://git@github.com:passwork-me/passwork-python.git
+RUN pip install --no-cache-dir git+https://github.com/passwork-me/passwork-python.git
 
 # Create a non-root user to run the CLI
 RUN groupadd -r passwork && useradd -r -g passwork passwork


### PR DESCRIPTION
Use HTTPS installation in Dockerfile

Installation with SSH requires the `openssh-client` package which is not installed by default on the `slim` version of the base image. And even with SSH, the process would fail with `ssh: Could not resolve hostname github.com:passwork-me: Name or service not known`.