### PR TITLE
feat: command for fast refreshing token

### DIFF
--- a/cli/commands/__init__.py
+++ b/cli/commands/__init__.py
@@ -1,6 +1,7 @@
-from .exec_command import ExecuteCommandStrategy
 from .api_command import ApiCallStrategy
+from .exec_command import ExecuteCommandStrategy
 from .get_command import GetCommandStrategy
+from .refresh_command import RefreshCommandStrategy
 from .update_command import UpdateCommandStrategy
 
 # Create a mapping of command names to strategy classes
@@ -8,5 +9,6 @@ COMMAND_STRATEGIES = {
     "exec": ExecuteCommandStrategy,
     "api": ApiCallStrategy,
     "get": GetCommandStrategy,
-    "update": UpdateCommandStrategy
+    "update": UpdateCommandStrategy,
+    "refresh": RefreshCommandStrategy,
 }

--- a/cli/commands/refresh_command.py
+++ b/cli/commands/refresh_command.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import json
+
+from .api_command import ApiCallStrategy
+from .base import PassworkCommand
+
+
+class RefreshCommandStrategy(ApiCallStrategy):
+    """Refresh the access token using the configured refresh token."""
+
+    def execute(self, client, args):
+        args.endpoint = "v1/sessions/refresh"
+        args.params = json.dumps({"refreshToken": client.refresh_token})
+        args.method = "POST"
+        args.field = None
+        return super().execute(client, args)
+
+    @staticmethod
+    def add_command(subparsers):
+        params = PassworkCommand.base_params()
+
+        parser = subparsers.add_parser(
+            "refresh", help="Refresh access token using the refresh token"
+        )
+        for key, value in params.items():
+            parser.add_argument(key, **value)


### PR DESCRIPTION
I have a problem similar to #6. To solve this, I added a token refresh command that fetches the refresh token from an environment variable and immediately sends a request to a specific endpoint: `v1/sessions/refresh`.