### PR TITLE
fix JSONDecodeError in _process_response

### DIFF
--- a/passwork_client/modules/api_client.py
+++ b/passwork_client/modules/api_client.py
@@ -55,7 +55,10 @@ class ApiClient:
 
     def _process_response(self, response):
         """Process API response and handle errors."""
-        data = response.json()
+        try:
+            data = response.json()
+        except json.JSONDecodeError:
+            raise PassworkError(f"Response not in JSON format. Text: {response.text}")
         result = data
 
         if data and isinstance(data, dict):


### PR DESCRIPTION
Added error handling for when the server response isn't in JSON format.

If Passwork is behind some kind of reverse proxy and has a whitelist configured, the response will be a text 413 - Access Denied, and the client won't be able to fix it because a JSONDecodeError will be raised, which isn't a server response.

